### PR TITLE
Skip logging duplicate keygen errors

### DIFF
--- a/pkg/eventconsumer/keygen_consumer.go
+++ b/pkg/eventconsumer/keygen_consumer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fystack/mpcium/pkg/logger"
 	"github.com/fystack/mpcium/pkg/messaging"
 	"github.com/fystack/mpcium/pkg/mpc"
+	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -142,7 +143,10 @@ func (sc *keygenConsumer) handleKeygenEvent(msg jetstream.Msg) {
 	}()
 
 	// Publish the signing event with the reply inbox.
-	if err := sc.pubsub.PublishWithReply(MPCGenerateEvent, replyInbox, msg.Data()); err != nil {
+	headers := map[string]string{
+		"SessionID": uuid.New().String(),
+	}
+	if err := sc.pubsub.PublishWithReply(MPCGenerateEvent, replyInbox, msg.Data(), headers); err != nil {
 		logger.Error("KeygenConsumer: Failed to publish signing event with reply", err)
 		_ = msg.Nak()
 		return

--- a/pkg/eventconsumer/sign_consumer.go
+++ b/pkg/eventconsumer/sign_consumer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fystack/mpcium/pkg/logger"
 	"github.com/fystack/mpcium/pkg/messaging"
 	"github.com/fystack/mpcium/pkg/mpc"
+	"github.com/google/uuid"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/spf13/viper"
@@ -158,7 +159,10 @@ func (sc *signingConsumer) handleSigningEvent(msg jetstream.Msg) {
 	}()
 
 	// Publish the signing event with the reply inbox.
-	if err := sc.pubsub.PublishWithReply(MPCSignEvent, replyInbox, msg.Data()); err != nil {
+	headers := map[string]string{
+		"SessionID": uuid.New().String(),
+	}
+	if err := sc.pubsub.PublishWithReply(MPCSignEvent, replyInbox, msg.Data(), headers); err != nil {
 		logger.Error("SigningConsumer: Failed to publish signing event with reply", err)
 		_ = msg.Nak()
 		return


### PR DESCRIPTION
- Introduce composeKeygenIdempotentKey to generate an idempotent key based on walletID and the NATS SessionID header

- Update all genKeyResultQueue.Enqueue calls to use the composed idempotent key

- Remove the verbose logger.Warn("Keygen session error", …) block to avoid logging expected duplicate‐event errors

Extend PubSub.PublishWithReply to accept a headers map and propagate a unique SessionID on each publish

- Update keygenConsumer and signingConsumer to include a randomly generated SessionID header on every PublishWithReply call

This is to fix #56 