### PR TITLE
Enhance error handle  when signing with duplicate tx_id (Issue #60)

### DIFF
--- a/pkg/event/types.go
+++ b/pkg/event/types.go
@@ -137,6 +137,8 @@ func GetErrorCodeFromError(err error) ErrorCode {
 		return ErrorCodeContextCancelled
 	case contains(errStr, "invalid signature from initiator"):
 		return ErrorCodeInvalidInitiatorSignature
+	case contains(errStr, "duplicate"):
+		return ErrorCodeSessionDuplicate
 	default:
 		return ErrorCodeUnknown
 	}

--- a/pkg/eventconsumer/event_consumer.go
+++ b/pkg/eventconsumer/event_consumer.go
@@ -329,7 +329,7 @@ func (ec *eventConsumer) consumeTxSigningEvent() error {
 				msg.TxID,
 				msg.NetworkInternalCode,
 				duplicateErr,
-				"Duplicate signing request detected",
+				"Duplicate session",
 				natMsg,
 			)
 			return

--- a/pkg/eventconsumer/event_consumer.go
+++ b/pkg/eventconsumer/event_consumer.go
@@ -814,9 +814,12 @@ func composeKeygenIdempotentKey(walletID string, natMsg *nats.Msg) string {
 }
 
 func composeSigningIdempotentKey(txID string, natMsg *nats.Msg) string {
+	var uniqueKey string
 	sid := natMsg.Header.Get("SessionID")
 	if sid != "" {
-		return fmt.Sprintf("%s:%s", txID, sid)
+		uniqueKey = fmt.Sprintf("%s:%s", txID, sid)
+	} else {
+		uniqueKey = txID
 	}
-	return txID
+	return fmt.Sprintf(mpc.TypeSigningResultFmt, uniqueKey)
 }

--- a/pkg/eventconsumer/event_consumer.go
+++ b/pkg/eventconsumer/event_consumer.go
@@ -323,6 +323,15 @@ func (ec *eventConsumer) consumeTxSigningEvent() error {
 
 		// Check for duplicate session and track if new
 		if ec.checkDuplicateSession(msg.WalletID, msg.TxID) {
+			duplicateErr := fmt.Errorf("duplicate signing request detected for walletID=%s txID=%s", msg.WalletID, msg.TxID)
+			ec.handleSigningSessionError(
+				msg.WalletID,
+				msg.TxID,
+				msg.NetworkInternalCode,
+				duplicateErr,
+				"Duplicate signing request detected",
+				natMsg,
+			)
 			return
 		}
 

--- a/pkg/mpc/ecdsa_signing_session.go
+++ b/pkg/mpc/ecdsa_signing_session.go
@@ -52,6 +52,7 @@ func newECDSASigningSession(
 	keyinfoStore keyinfo.Store,
 	resultQueue messaging.MessageQueue,
 	identityStore identity.Store,
+	idempotentKey string,
 ) *ecdsaSigningSession {
 	return &ecdsaSigningSession{
 		session: session{
@@ -81,6 +82,7 @@ func newECDSASigningSession(
 			getRoundFunc:  GetEcdsaMsgRound,
 			resultQueue:   resultQueue,
 			identityStore: identityStore,
+			idempotentKey: idempotentKey,
 		},
 		endCh:               make(chan *common.SignatureData),
 		txID:                txID,
@@ -178,7 +180,7 @@ func (s *ecdsaSigningSession) Sign(onSuccess func(data []byte)) {
 			}
 
 			err = s.resultQueue.Enqueue(event.SigningResultCompleteTopic, bytes, &messaging.EnqueueOptions{
-				IdempotententKey: s.txID,
+				IdempotententKey: s.idempotentKey,
 			})
 			if err != nil {
 				s.ErrCh <- errors.Wrap(err, "Failed to publish sign success message")

--- a/pkg/mpc/eddsa_signing_session.go
+++ b/pkg/mpc/eddsa_signing_session.go
@@ -43,6 +43,7 @@ func newEDDSASigningSession(
 	keyinfoStore keyinfo.Store,
 	resultQueue messaging.MessageQueue,
 	identityStore identity.Store,
+	idempotentKey string,
 ) *eddsaSigningSession {
 	return &eddsaSigningSession{
 		session: session{
@@ -72,6 +73,7 @@ func newEDDSASigningSession(
 			getRoundFunc:  GetEddsaMsgRound,
 			resultQueue:   resultQueue,
 			identityStore: identityStore,
+			idempotentKey:  idempotentKey,
 		},
 		endCh:               make(chan *common.SignatureData),
 		txID:                txID,
@@ -167,7 +169,7 @@ func (s *eddsaSigningSession) Sign(onSuccess func(data []byte)) {
 			}
 
 			err = s.resultQueue.Enqueue(event.SigningResultCompleteTopic, bytes, &messaging.EnqueueOptions{
-				IdempotententKey: s.txID,
+				IdempotententKey: s.idempotentKey,
 			})
 			if err != nil {
 				s.ErrCh <- errors.Wrap(err, "Failed to publish sign success message")

--- a/pkg/mpc/node.go
+++ b/pkg/mpc/node.go
@@ -165,6 +165,7 @@ func (p *Node) CreateSigningSession(
 	txID string,
 	networkInternalCode string,
 	resultQueue messaging.MessageQueue,
+	idempotentKey string,
 ) (SigningSession, error) {
 	version := p.getVersion(sessionType, walletID)
 	keyInfo, err := p.getKeyInfo(sessionType, walletID)
@@ -211,6 +212,7 @@ func (p *Node) CreateSigningSession(
 			p.keyinfoStore,
 			resultQueue,
 			p.identityStore,
+			idempotentKey,
 		), nil
 
 	case SessionTypeEDDSA:
@@ -228,6 +230,7 @@ func (p *Node) CreateSigningSession(
 			p.keyinfoStore,
 			resultQueue,
 			p.identityStore,
+			idempotentKey,
 		), nil
 	}
 

--- a/pkg/mpc/session.go
+++ b/pkg/mpc/session.go
@@ -22,6 +22,7 @@ type SessionType string
 const (
 	TypeGenerateWalletResultFmt = "mpc.mpc_keygen_result.%s"
 	TypeReshareWalletResultFmt  = "mpc.mpc_reshare_result.%s"
+	TypeSigningResultFmt        = "mpc.mpc_signing_result.%s"
 
 	SessionTypeECDSA SessionType = "session_ecdsa"
 	SessionTypeEDDSA SessionType = "session_eddsa"

--- a/pkg/mpc/session.go
+++ b/pkg/mpc/session.go
@@ -72,8 +72,9 @@ type session struct {
 	getRoundFunc  GetRoundFunc
 	mu            sync.Mutex
 	// After the session is done, the key will be stored pubkeyBytes
-	pubkeyBytes []byte
-	sessionType SessionType
+	pubkeyBytes   []byte
+	sessionType   SessionType
+	idempotentKey string
 }
 
 func (s *session) PartyID() *tss.PartyID {


### PR DESCRIPTION
## Issue

When signing through `mpcClient.SignTransaction`, if the same `tx_id` is used multiple times, `mpcClient.OnSignResult` could not receive all results reliably. This happened because:

1. Each node generates its own signing session for the same `tx_id`
2. All nodes publish results to NATS with the same idempotent key (just the `tx_id`)
3. NATS drops subsequent messages with the same idempotent key, causing some results to be lost
4. The client only receives one response instead of all expected responses, and other request will be time out.

The issue was in the idempotent key generation for NATS messages. The signing sessions used only the `tx_id` as the idempotent key:


## How the Fix Works

1. When a signing request comes in, the event consumer extracts the `SessionID` from the NATS message header
2. It creates a composite idempotent key: `{tx_id}:{session_id}` 
3. This composite key is passed to the signing sessions during creation
4. When publishing results (both success and error), the sessions use this composite key
5. Now each session's results have unique idempotent keys, allowing all responses to reach the client

## NATS Message
Raw Data: 
```
{
  "result_type": "error",
  "error_code": "ERROR_SESSION_DUPLICATE",
  "error_reason": "Duplicate session: duplicate signing request detected for walletID=244924ee-f604-4ebb-a2bf-f844a9888e2c:0 txID=duplicate-test-1754222214845",
  "is_timeout": false,
  "network_internal_code": "solana:devnet",
  "wallet_id": "244924ee-f604-4ebb-a2bf-f844a9888e2c:0",
  "tx_id": "duplicate-test-1754222214845",
  "r": null,
  "s": null,
  "signature_recovery": null,
  "signature": null
}
```
Headers: `Nats-Msg-Id: duplicate-test-1754222214845:b7325da2-abd9-4c08-b889-88fddb657af7`

## Testing
From my end, I tested by sending 5 signing requests with the same tx_id.
Only the first request succeeded
The others correctly returned `ERROR_SESSION_DUPLICATE`
