### PR TITLE
Only ensure node is in participant list if not new peer for resharing logic

### DIFF
--- a/pkg/mpc/node.go
+++ b/pkg/mpc/node.go
@@ -340,8 +340,10 @@ func (p *Node) CreateReshareSession(
 		return nil, fmt.Errorf("not enough peers to create resharing session! expected %d, got %d", oldKeyInfo.Threshold+1, len(readyOldParticipantIDs))
 	}
 
-	if err := p.ensureNodeIsParticipant(oldKeyInfo); err != nil {
-		return nil, err
+	if !isNewPeer {
+		if err := p.ensureNodeIsParticipant(oldKeyInfo); err != nil {
+			return nil, err
+		}
 	}
 
 	// 5. Generate party IDs


### PR DESCRIPTION
 Only check if node is in old participant list for existing nodesNew nodes are not expected to be in the old participant list
