### PR TITLE
Automatically disconnect and remove the peer from consul registry

### DIFF
--- a/cmd/mpcium/main.go
+++ b/cmd/mpcium/main.go
@@ -162,7 +162,7 @@ func runNode(ctx context.Context, c *cli.Command) error {
 	logger.Info("Node is running", "ID", nodeID, "name", nodeName)
 
 	peerNodeIDs := GetPeerIDs(peers)
-	peerRegistry := mpc.NewRegistry(nodeID, peerNodeIDs, consulClient.KV())
+	peerRegistry := mpc.NewRegistry(nodeID, peerNodeIDs, consulClient.KV(), directMessaging)
 
 	mpcNode := mpc.NewNode(
 		nodeID,
@@ -231,6 +231,11 @@ func runNode(ctx context.Context, c *cli.Command) error {
 
 		if err := ecdhSession.Close(); err != nil {
 			logger.Error("Failed to close ECDH session", err)
+		}
+
+		err := natsConn.Drain()
+		if err != nil {
+			logger.Error("Failed to drain NATS connection", err)
 		}
 	}()
 

--- a/pkg/eventconsumer/keygen_consumer.go
+++ b/pkg/eventconsumer/keygen_consumer.go
@@ -90,10 +90,10 @@ func (sc *keygenConsumer) Run(ctx context.Context) error {
 		sc.handleKeygenEvent,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to subscribe to signing events: %w", err)
+		return fmt.Errorf("failed to subscribe to keygen events: %w", err)
 	}
 	sc.jsSub = sub
-	logger.Info("SigningConsumer: Subscribed to signing events")
+	logger.Info("SigningConsumer: Subscribed to keygen events")
 
 	// Block until context cancellation.
 	<-ctx.Done()


### PR DESCRIPTION
# Automatically disconnect and remove unresponsive peers from Consul registry

## Description
This PR enhances peer health management in the MPC node registry to ensure disconnected or unresponsive peers are automatically removed from Consul.

## Key Changes
### `registry`
- Added `healthCheck` using `DirectMessaging` to actively probe peers via NATS.
- Implemented `checkPeersHealth` routine that periodically sends health check messages to all ready peers.
- If a peer does not respond (detected by `"no responders"` error), its `ready` key is deleted from Consul.
- Updated `NewRegistry` to accept `directMessaging` for health checks.

### `point2point`
- Added `SendToOtherWithRetry` method with configurable retry attempts, delays, and backoff for reliable health checks.
- Improved `Listen` method to handle subscription flush errors and clean up on failure.

### `main.go`
- Updated `NewRegistry` initialization to pass in `directMessaging`.
- Added NATS `Drain()` call during shutdown for clean disconnection.

### `keygen_consumer`
- Fixed log messages to correctly reference keygen events instead of signing events.

## Impact
- Ensures the registry always reflects the actual set of active peers.
- Reduces stale peer entries in Consul, preventing potential coordination or signing errors.
- Improves node reliability and self-healing in multi-peer setups.
