### PR TITLE
refactor: IAM Default Credential Chain when aws.kms_key_id is configured in signer example

### DIFF
--- a/examples/sign/main.go
+++ b/examples/sign/main.go
@@ -57,16 +57,14 @@ func main() {
 	defer natsConn.Drain()
 	defer natsConn.Close()
 
-	localSigner, err := client.NewLocalSigner(types.EventInitiatorKeyType(algorithm), client.LocalSignerOptions{
-		KeyPath: "./event_initiator.key",
-	})
+	signer, err := newSigner(types.EventInitiatorKeyType(algorithm))
 	if err != nil {
-		logger.Fatal("Failed to create local signer", err)
+		logger.Fatal("Failed to create signer", err)
 	}
 
 	mpcClient := client.NewMPCClient(client.Options{
 		NatsConn: natsConn,
-		Signer:   localSigner,
+		Signer:   signer,
 		ClientID: *clientID,
 	})
 
@@ -103,4 +101,21 @@ func main() {
 	<-stop
 
 	fmt.Println("Shutting down.")
+}
+
+
+// newSigner returns a KMSSigner if aws.kms_key_id is configured, otherwise falls back to the local key file.
+// In IAM-aware environments (Recommended in Production) no credentials are needed —
+// set aws.kms_key_id and aws.region in config.yaml and the SDK handles the rest.
+func newSigner(keyType types.EventInitiatorKeyType) (client.Signer, error) {
+	if kmsKeyID := viper.GetString("aws.kms_key_id"); kmsKeyID != "" {
+		return client.NewKMSSigner(keyType, client.KMSSignerOptions{
+			Region: viper.GetString("aws.region"),
+			KeyID:  kmsKeyID,
+		})
+	}
+
+	return client.NewLocalSigner(keyType, client.LocalSignerOptions{
+		KeyPath: "./event_initiator.key",
+	})
 }

--- a/pkg/client/kms_signer.go
+++ b/pkg/client/kms_signer.go
@@ -28,8 +28,8 @@ type KMSSignerOptions struct {
 	Region          string // AWS region (e.g., "us-east-1", "us-west-2") - Required
 	KeyID           string // AWS KMS key ID or ARN - Required
 	EndpointURL     string // Custom endpoint URL (optional, for LocalStack/custom services)
-	AccessKeyID     string // AWS access key ID (optional, uses default credential chain if not provided)
-	SecretAccessKey string // AWS secret access key (optional, uses default credential chain if not provided)
+	AccessKeyID     string // AWS access key ID (optional, for local/LocalStack only — recommended to leave empty in production to use the Default Credential Chain)
+	SecretAccessKey string // AWS secret access key (optional, for local/LocalStack only — recommended to leave empty in production to use the Default Credential Chain)
 }
 
 // NewKMSSigner creates a new KMSSigner using AWS KMS


### PR DESCRIPTION
Addresses #152 by refactoring examples/sign/main.go to prefer the IAM Default Credential Chain when aws.kms_key_id is configured, falling back to the local signer for dev. Also updated KMSSignerOptions docstrings to discourage static credentials in production.

@anhthii thank you so much, I see updates on the other documentations, well done