### PR TITLE
fix(mpc): return error instead of panic when publicKey is nil in BroadcastPublicKey

### DIFF
--- a/pkg/mpc/key_exchange_session.go
+++ b/pkg/mpc/key_exchange_session.go
@@ -152,6 +152,13 @@ func (s *ecdhSession) Close() error {
 }
 
 func (e *ecdhSession) BroadcastPublicKey() error {
+	// Peer restart mid-handshake can schedule this broadcast goroutine
+	// before the local publicKey is populated; crypto/ecdh.(*PublicKey).Bytes
+	// then panics with nil pointer dereference. Return an error so the
+	// caller's retrigger logic takes over instead of the goroutine dying.
+	if e == nil || e.publicKey == nil {
+		return fmt.Errorf("ecdh session %s has no public key to broadcast yet", e.nodeID)
+	}
 	publicKeyBytes := e.publicKey.Bytes()
 	msg := types.ECDHMessage{
 		From:      e.nodeID,


### PR DESCRIPTION
Fixes fystack/mpcium#158.

## Problem

`registerReadyPairs` schedules `triggerECDHExchange` → `BroadcastPublicKey` from a goroutine. If the peer restarts between scheduling and reading the local publicKey, `e.publicKey` is nil and `crypto/ecdh.(*PublicKey).Bytes` panics:

```
panic: runtime error: invalid memory address or nil pointer dereference
crypto/ecdh.(*PublicKey).Bytes
mpc.(*ecdhSession).BroadcastPublicKey key_exchange_session.go:155
mpc.(*registry).triggerECDHExchange registry.go:164
```

It self-heals via container restart + ECDH retrigger but each hit adds ~10-15s before the node rejoins quorum during rolling restarts, and the stderr panics pollute log shipping.

## Fix

Nil-check the receiver and `e.publicKey` at the top of `BroadcastPublicKey`. Return a descriptive error so the caller's retrigger path handles it cleanly instead of a panic propagating to stderr.

## Test

`go build ./...` and `go test ./pkg/mpc/...` pass locally.