### PR TITLE
fix(types): bind derivation_path in SignTxMessage.Raw() (#162)

### DIFF
--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 
@@ -765,4 +767,33 @@ func TestAuthorizeInitiatorMessage_NilSignature(t *testing.T) {
 	if err == nil {
 		t.Error("AuthorizeInitiatorMessage() should fail with nil signature")
 	}
+}
+
+func TestVerifyInitiatorMessage_DerivationPathBound(t *testing.T) {
+	pub, priv, _ := generateTestEd25519Key()
+
+	store := &fileStore{
+		initiatorKey: &InitiatorKey{
+			Algorithm: types.EventInitiatorKeyTypeEd25519,
+			Ed25519:   pub,
+		},
+	}
+
+	msg := &types.SignTxMessage{
+		KeyType:             types.KeyTypeSecp256k1,
+		WalletID:            "w",
+		NetworkInternalCode: "ETH",
+		TxID:                "tx",
+		Tx:                  []byte("d"),
+		DerivationPath:      []uint32{44, 60, 0, 0, 0, 1},
+	}
+	raw, err := msg.Raw()
+	require.NoError(t, err)
+	msg.Signature = ed25519.Sign(priv, raw)
+
+	require.NoError(t, store.VerifyInitiatorMessage(msg), "should verify")
+
+	// tamper path
+	msg.DerivationPath = []uint32{44, 60, 0, 0, 0, 999}
+	assert.Error(t, store.VerifyInitiatorMessage(msg), "should not verify")
 }

--- a/pkg/types/initiator_msg.go
+++ b/pkg/types/initiator_msg.go
@@ -64,17 +64,19 @@ type ResharingMessage struct {
 func (m *SignTxMessage) Raw() ([]byte, error) {
 	// omit the Signature field itself when computing the signed‐over data
 	payload := struct {
-		KeyType             KeyType `json:"key_type"`
-		WalletID            string  `json:"wallet_id"`
-		NetworkInternalCode string  `json:"network_internal_code"`
-		TxID                string  `json:"tx_id"`
-		Tx                  []byte  `json:"tx"`
+		KeyType             KeyType  `json:"key_type"`
+		WalletID            string   `json:"wallet_id"`
+		NetworkInternalCode string   `json:"network_internal_code"`
+		TxID                string   `json:"tx_id"`
+		Tx                  []byte   `json:"tx"`
+		DerivationPath      []uint32 `json:"derivation_path,omitempty"`
 	}{
 		KeyType:             m.KeyType,
 		WalletID:            m.WalletID,
 		NetworkInternalCode: m.NetworkInternalCode,
 		TxID:                m.TxID,
 		Tx:                  m.Tx,
+		DerivationPath:      m.DerivationPath,
 	}
 	return json.Marshal(payload)
 }

--- a/pkg/types/initiator_msg_test.go
+++ b/pkg/types/initiator_msg_test.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/json"
 	"testing"
 
@@ -208,4 +210,50 @@ func TestGenerateKeyMessage_EmptyWallet(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []byte(""), raw)
 	assert.Equal(t, "", msg.InitiatorID())
+}
+
+func TestSignTxMessage_Raw_IncludesDerivationPath(t *testing.T) {
+	msg := &SignTxMessage{
+		KeyType:             KeyTypeSecp256k1,
+		WalletID:            "wallet-123",
+		NetworkInternalCode: "BTC",
+		TxID:                "tx-456",
+		Tx:                  []byte("transaction-data"),
+		Signature:           []byte("signature-data"),
+		DerivationPath:      []uint32{44, 60, 0, 0, 0, 1},
+	}
+	raw, err := msg.Raw()
+	require.NoError(t, err)
+	assert.NotEmpty(t, raw)
+	assert.Contains(t, string(raw), `"derivation_path":[44,60,0,0,0,1]`)
+}
+
+func TestSignTxMessage_DerivationPathIsSignatureBound(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	msg := &SignTxMessage{
+		KeyType:             KeyTypeSecp256k1,
+		WalletID:            "w",
+		NetworkInternalCode: "ETH",
+		TxID:                "tx",
+		Tx:                  []byte("d"),
+		DerivationPath:      []uint32{44, 60, 0, 0, 1},
+	}
+
+	// initiator sign on Raw()
+	raw, err := msg.Raw()
+	require.NoError(t, err)
+	assert.NotEmpty(t, raw)
+	sig := ed25519.Sign(priv, raw)
+
+	// verify pass
+	rawOK, _ := msg.Raw()
+	assert.True(t, ed25519.Verify(pub, rawOK, sig), "original raw should be valid")
+
+	// Attacker: change derivation_path, same sig
+	msg.DerivationPath = []uint32{44, 60, 0, 0, 2}
+	rawTempered, err := msg.Raw()
+	require.NoError(t, err)
+	assert.False(t, ed25519.Verify(pub, rawTempered, sig), "changed derivation_path should invalidate sig")
 }


### PR DESCRIPTION
## Summary

Fixes the signature-binding gap reported in #162.

`SignTxMessage.Raw()` builds the canonical payload that the event initiator signs and that nodes re-compute during verification. It previously **omitted `derivation_path`**, even though nodes use that field to select the child key for signing (`CKD.Derive`). An attacker able to tamper messages on the bus could change `derivation_path` **without invalidating the initiator signature**, making a node sign the authenticated tx digest with a different derived key than intended. Because `ComposeAuthorizerRaw()` wraps `Raw()`, authorizer signatures were affected as well.

## Change

- Include `DerivationPath` in the signed payload of `SignTxMessage.Raw()`.
- `ComposeAuthorizerRaw()` now covers it automatically (it wraps `Raw()`).

## Backward compatibility

Uses `json:"derivation_path,omitempty"`. Messages with an empty `derivation_path` serialize **byte-for-byte** as before, so existing signed traffic (initiators that don't use HD derivation) keeps verifying — no lockstep upgrade required for the empty-path case.

## Tests

- `pkg/types`: backward-compat bytes (empty path == old output), path inclusion, path changes Raw(), and the **signature-binding** property (tampering the path breaks `ed25519.Verify`).
- `pkg/identity`: `VerifyInitiatorMessage` end-to-end — a tampered `derivation_path` is rejected through the production verify path.

`go test ./pkg/types/... ./pkg/identity/...` passes; `gofmt`/`go build ./...` clean.

## Note for downstream initiators

Initiators that build & sign `SignTxMessage` (e.g. the coordinator/API) must use the **same** `[]uint32 derivation_path` type and include it in their own `Raw()` once they start sending non-empty paths, to keep the canonical bytes identical on both sides.

Relates to #162